### PR TITLE
String allocations optimize

### DIFF
--- a/src/slackclient.cpp
+++ b/src/slackclient.cpp
@@ -875,9 +875,9 @@ void SlackClient::handleMarkChannelReply()
 
 void SlackClient::postMessage(const QString& channelId, QString content)
 {
-    content.replace("&", "&amp;");
-    content.replace(">", "&gt;");
-    content.replace("<", "&lt;");
+    content.replace(QLatin1Char('&'), QStringLiteral("&amp;"));
+    content.replace(QLatin1Char('>'), QStringLiteral("&gt;"));
+    content.replace(QLatin1Char('<'), QStringLiteral("&lt;"));
 
     QMap<QString, QString> data;
     data.insert(QStringLiteral("channel"), channelId);

--- a/src/slackclient.cpp
+++ b/src/slackclient.cpp
@@ -42,7 +42,7 @@ SlackClient::SlackClient(QObject *parent) :
 SlackClient::~SlackClient()
 {
     QSettings settings;
-    settings.setValue("LastChannel", m_lastChannel);
+    settings.setValue(QStringLiteral("LastChannel"), m_lastChannel);
 }
 
 void SlackClient::setAppActive(bool active)
@@ -111,105 +111,108 @@ void SlackClient::handleStreamEnd()
     reconnectTimer->start(1000);
 }
 
-void SlackClient::handleStreamMessage(QJsonObject message)
+void SlackClient::handleStreamMessage(const QJsonObject& message)
 {
-    const QString& type = message.value("type").toString();
+    const QString& type = message.value(QStringLiteral("type")).toString();
 
-    if (type == "message") {
+    if (type == QStringLiteral("message")) {
         parseMessageUpdate(message);
-    } else if (type == "group_marked" || type == "channel_marked" || type == "im_marked" || type == "mpim_marked") {
+    } else if (type == QStringLiteral("group_marked") ||
+               type == QStringLiteral("channel_marked") ||
+               type == QStringLiteral("im_marked") ||
+               type == QStringLiteral("mpim_marked")) {
         parseChannelUpdate(message);
-    } else if (type == "channel_joined") {
+    } else if (type == QStringLiteral("channel_joined")) {
         parseChannelJoin(message);
-    } else if (type == "group_joined") {
+    } else if (type == QStringLiteral("group_joined")) {
         parseGroupJoin(message);
-    } else if (type == "im_open") {
+    } else if (type == QStringLiteral("im_open")) {
         parseChatOpen(message);
-    } else if (type == "im_close") {
+    } else if (type == QStringLiteral("im_close")) {
         parseChatClose(message);
-    } else if (type == "channel_left" || type == "group_left") {
+    } else if (type == QStringLiteral("channel_left") || type == QStringLiteral("group_left")) {
         parseChannelLeft(message);
-    } else if (type == "presence_change" || type == "manual_presence_change") {
+    } else if (type == QStringLiteral("presence_change") || type == QStringLiteral("manual_presence_change")) {
         parsePresenceChange(message);
-    } else if (type == "desktop_notification") {
+    } else if (type == QStringLiteral("desktop_notification")) {
         parseNotification(message);
     }
 }
 
-void SlackClient::parseChatOpen(QJsonObject message)
+void SlackClient::parseChatOpen(const QJsonObject& message)
 {
-    QString id = message.value("channel").toString();
+    QString id = message.value(QStringLiteral("channel")).toString();
     QVariantMap channel = Storage::channel(id);
-    channel.insert("isOpen", QVariant(true));
+    channel.insert(QStringLiteral("isOpen"), QVariant(true));
     Storage::saveChannel(channel);
     emit channelJoined(channel);
 }
 
-void SlackClient::parseChatClose(QJsonObject message)
+void SlackClient::parseChatClose(const QJsonObject& message)
 {
-    QString id = message.value("channel").toString();
+    QString id = message.value(QStringLiteral("channel")).toString();
     QVariantMap channel = Storage::channel(id);
-    channel.insert("isOpen", QVariant(false));
+    channel.insert(QStringLiteral("isOpen"), QVariant(false));
     Storage::saveChannel(channel);
     emit channelLeft(channel);
 }
 
-void SlackClient::parseChannelJoin(QJsonObject message)
+void SlackClient::parseChannelJoin(const QJsonObject& message)
 {
-    QVariantMap data = parseChannel(message.value("channel").toObject());
+    QVariantMap data = parseChannel(message.value(QStringLiteral("channel")).toObject());
     Storage::saveChannel(data);
     emit channelJoined(data);
 }
 
-void SlackClient::parseChannelLeft(QJsonObject message)
+void SlackClient::parseChannelLeft(const QJsonObject& message)
 {
-    QString id = message.value("channel").toString();
+    QString id = message.value(QStringLiteral("channel")).toString();
     QVariantMap channel = Storage::channel(id);
-    channel.insert("isOpen", QVariant(false));
+    channel.insert(QStringLiteral("isOpen"), QVariant(false));
     Storage::saveChannel(channel);
     emit channelLeft(channel);
 }
 
-void SlackClient::parseGroupJoin(QJsonObject message)
+void SlackClient::parseGroupJoin(const QJsonObject& message)
 {
-    QVariantMap data = parseGroup(message.value("channel").toObject());
+    QVariantMap data = parseGroup(message.value(QStringLiteral("channel")).toObject());
     Storage::saveChannel(data);
     emit channelJoined(data);
 }
 
-void SlackClient::parseChannelUpdate(QJsonObject message)
+void SlackClient::parseChannelUpdate(const QJsonObject& message)
 {
-    QString id = message.value("channel").toString();
+    QString id = message.value(QStringLiteral("channel")).toString();
     QVariantMap channel = Storage::channel(id);
-    channel.insert("lastRead", message.value("ts").toVariant());
-    channel.insert("unreadCount", message.value("unread_count_display").toVariant());
+    channel.insert(QStringLiteral("lastRead"), message.value(QStringLiteral("ts")).toVariant());
+    channel.insert(QStringLiteral("unreadCount"), message.value(QStringLiteral("unread_count_display")).toVariant());
     Storage::saveChannel(channel);
     emit channelUpdated(channel);
 }
 
-void SlackClient::parseMessageUpdate(QJsonObject message)
+void SlackClient::parseMessageUpdate(const QJsonObject& message)
 {
     QVariantMap data = getMessageData(message);
 
-    QString channelId = message.value("channel").toString();
+    QString channelId = message.value(QStringLiteral("channel")).toString();
     if (Storage::channelMessagesExist(channelId)) {
         Storage::appendChannelMessage(channelId, data);
     }
 
     QVariantMap channel = Storage::channel(channelId);
 
-    QString messageTime = data.value("time").toString();
-    QString latestRead = channel.value("lastRead").toString();
+    QString messageTime = data.value(QStringLiteral("time")).toString();
+    QString latestRead = channel.value(QStringLiteral("lastRead")).toString();
 
     if (messageTime > latestRead) {
-        int unreadCount = channel.value("unreadCount").toInt() + 1;
-        channel.insert("unreadCount", unreadCount);
+        int unreadCount = channel.value(QStringLiteral("unreadCount")).toInt() + 1;
+        channel.insert(QStringLiteral("unreadCount"), unreadCount);
         Storage::saveChannel(channel);
         emit channelUpdated(channel);
     }
 
-    if (channel.value("isOpen").toBool() == false) {
-        if (channel.value("type").toString() == "im") {
+    if (channel.value(QStringLiteral("isOpen")).toBool() == false) {
+        if (channel.value(QStringLiteral("type")).toString() == QStringLiteral("im")) {
             openChat(channelId);
         }
     }
@@ -217,38 +220,39 @@ void SlackClient::parseMessageUpdate(QJsonObject message)
     emit messageReceived(data);
 }
 
-void SlackClient::parsePresenceChange(QJsonObject message)
+void SlackClient::parsePresenceChange(const QJsonObject& message)
 {
-    QVariant userId = message.value("user").toVariant();
-    QVariant presence = message.value("presence").toVariant();
+    QVariant userId = message.value(QStringLiteral("user")).toVariant();
+    QVariant presence = message.value(QStringLiteral("presence")).toVariant();
 
     QVariantMap user = Storage::user(userId);
     if (!user.isEmpty()) {
-        user.insert("presence", presence);
+        user.insert(QStringLiteral("presence"), presence);
         Storage::saveUser(user);
         emit userUpdated(user);
     }
 
-    foreach (QVariant item, Storage::channels()) {
+    foreach (const auto item, Storage::channels()) {
         QVariantMap channel = item.toMap();
 
-        if (channel.value("type") == QVariant("im") && channel.value("userId") == userId) {
-            channel.insert("presence", presence);
+        if (channel.value(QStringLiteral("type")) == QVariant(QStringLiteral("im")) &&
+                channel.value(QStringLiteral("userId")) == userId) {
+            channel.insert(QStringLiteral("presence"), presence);
             Storage::saveChannel(channel);
             emit channelUpdated(channel);
         }
     }
 }
 
-void SlackClient::parseNotification(QJsonObject message)
+void SlackClient::parseNotification(const QJsonObject& message)
 {
-    QString channel = message.value("subtitle").toString();
-    QString content = message.value("content").toString();
+    QString channel = message.value(QStringLiteral("subtitle")).toString();
+    QString content = message.value(QStringLiteral("content")).toString();
 
-    QString channelId = message.value("channel").toString();
+    QString channelId = message.value(QStringLiteral("channel")).toString();
     QString title;
 
-    if (channelId.startsWith("C") || channelId.startsWith("G")) {
+    if (channelId.startsWith(QLatin1Char('C')) || channelId.startsWith(QLatin1Char('G'))) {
         title = QString(tr("New message in %1")).arg(channel);
     } else if (channelId.startsWith("D")) {
         title = QString(tr("New message from %1")).arg(channel);
@@ -265,6 +269,9 @@ void SlackClient::parseNotification(QJsonObject message)
 
 bool SlackClient::isOk(const QNetworkReply *reply)
 {
+    if (!reply) {
+        return false;
+    }
     int statusCode = reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
 
     if (statusCode / 100 == 2) {
@@ -287,7 +294,7 @@ bool SlackClient::isError(const QJsonObject &data)
         qWarning() << "No data received";
         return true;
     } else {
-        return !data.value("ok").toBool(false);
+        return !data.value(QStringLiteral("ok")).toBool(false);
     }
 }
 
@@ -308,16 +315,16 @@ QJsonObject SlackClient::getResult(QNetworkReply *reply)
     }
 }
 
-QNetworkReply *SlackClient::executeGet(QString method, QMap<QString, QString> params)
+QNetworkReply *SlackClient::executeGet(const QString& method, const QMap<QString, QString>& params)
 {
     QUrlQuery query;
-    query.addQueryItem("token", config->accessToken());
+    query.addQueryItem(QStringLiteral("token"), config->accessToken());
 
     foreach (const QString key, params.keys()) {
         query.addQueryItem(key, params.value(key));
     }
 
-    QUrl url("https://slack.com/api/" + method);
+    QUrl url(QStringLiteral("https://slack.com/api/") + method);
     url.setQuery(query);
     QNetworkRequest request(url);
 
@@ -325,10 +332,10 @@ QNetworkReply *SlackClient::executeGet(QString method, QMap<QString, QString> pa
     return networkAccessManager->get(request);
 }
 
-QNetworkReply *SlackClient::executePost(QString method, const QMap<QString, QString> &data)
+QNetworkReply *SlackClient::executePost(const QString& method, const QMap<QString, QString> &data)
 {
     QUrlQuery query;
-    query.addQueryItem("token", config->accessToken());
+    query.addQueryItem(QStringLiteral("token"), config->accessToken());
 
     foreach (const QString key, data.keys()) {
         query.addQueryItem(key, data.value(key));
@@ -339,37 +346,38 @@ QNetworkReply *SlackClient::executePost(QString method, const QMap<QString, QStr
     QByteArray body = params.toEncoded(QUrl::EncodeUnicode | QUrl::EncodeReserved);
     body.remove(0, 1);
 
-    QUrl url("https://slack.com/api/" + method);
+    QUrl url(QStringLiteral("https://slack.com/api/") + method);
     QNetworkRequest request(url);
-    request.setHeader(QNetworkRequest::ContentTypeHeader, "application/x-www-form-urlencoded");
+    request.setHeader(QNetworkRequest::ContentTypeHeader, QStringLiteral("application/x-www-form-urlencoded"));
     request.setHeader(QNetworkRequest::ContentLengthHeader, body.length());
 
     qDebug() << "POST" << url.toString() << body;
     return networkAccessManager->post(request, body);
 }
 
-QNetworkReply *SlackClient::executePostWithFile(QString method, const QMap<QString, QString> &formdata, QFile *file)
+QNetworkReply *SlackClient::executePostWithFile(const QString& method, const QMap<QString, QString> &formdata, QFile *file)
 {
     QHttpMultiPart *dataParts = new QHttpMultiPart(QHttpMultiPart::FormDataType);
 
     QHttpPart tokenPart;
-    tokenPart.setHeader(QNetworkRequest::ContentDispositionHeader, "from-data; name=\"token\"");
+    tokenPart.setHeader(QNetworkRequest::ContentDispositionHeader, QStringLiteral("from-data; name=\"token\""));
     tokenPart.setBody(config->accessToken().toUtf8());
     dataParts->append(tokenPart);
 
     QHttpPart filePart;
-    filePart.setHeader(QNetworkRequest::ContentDispositionHeader, "from-data; name=\"file\"; filename=\"" + file->fileName() + "\"");
+    filePart.setHeader(QNetworkRequest::ContentDispositionHeader, QStringLiteral("from-data; name=\"file\"; filename=\"") + file->fileName() + "\"");
     filePart.setBodyDevice(file);
     dataParts->append(filePart);
 
     foreach (const QString key, formdata.keys()) {
         QHttpPart data;
-        data.setHeader(QNetworkRequest::ContentDispositionHeader, "form-data; name=\"" + key.toUtf8() + "\"");
+        data.setHeader(QNetworkRequest::ContentDispositionHeader, QStringLiteral("form-data; name=\"") +
+                       key.toUtf8() + QLatin1Char('"'));
         data.setBody(formdata.value(key).toUtf8());
         dataParts->append(data);
     }
 
-    QUrl url("https://slack.com/api/" + method);
+    QUrl url(QStringLiteral("https://slack.com/api/") + method);
     QNetworkRequest request(url);
 
     qDebug() << "POST" << url << dataParts;
@@ -380,10 +388,10 @@ QNetworkReply *SlackClient::executePostWithFile(QString method, const QMap<QStri
     return reply;
 }
 
-void SlackClient::fetchAccessToken(QUrl resultUrl)
+void SlackClient::fetchAccessToken(const QUrl& resultUrl)
 {
     QUrlQuery resultQuery(resultUrl);
-    QString code = resultQuery.queryItemValue("code");
+    QString code = resultQuery.queryItemValue(QStringLiteral("code"));
 
     if (code.isEmpty()) {
         emit accessTokenFail();
@@ -391,11 +399,11 @@ void SlackClient::fetchAccessToken(QUrl resultUrl)
     }
 
     QMap<QString, QString> params;
-    params.insert("client_id", m_clientId);
-    params.insert("client_secret", m_clientId2);
-    params.insert("code", code);
+    params.insert(QStringLiteral("client_id"), m_clientId);
+    params.insert(QStringLiteral("client_secret"), m_clientId2);
+    params.insert(QStringLiteral("code"), code);
 
-    QNetworkReply *reply = executeGet("oauth.access", params);
+    QNetworkReply *reply = executeGet(QStringLiteral("oauth.access"), params);
     connect(reply, &QNetworkReply::finished, this, &SlackClient::handleAccessTokenReply);
 }
 
@@ -410,10 +418,10 @@ void SlackClient::handleAccessTokenReply()
         return;
     }
 
-    QString accessToken = data.value("access_token").toString();
-    QString teamId = data.value("team_id").toString();
-    QString userId = data.value("user_id").toString();
-    QString teamName = data.value("team_name").toString();
+    QString accessToken = data.value(QStringLiteral("access_token")).toString();
+    QString teamId = data.value(QStringLiteral("team_id")).toString();
+    QString userId = data.value(QStringLiteral("user_id")).toString();
+    QString teamName = data.value(QStringLiteral("team_name")).toString();
     qDebug() << "Access token success" << accessToken << userId << teamId << teamName;
 
     config->setAccessToken(accessToken);
@@ -454,9 +462,9 @@ void SlackClient::handleTestLoginReply()
         return;
     }
 
-    QString teamId = data.value("team_id").toString();
-    QString userId = data.value("user_id").toString();
-    QString teamName = data.value("team").toString();
+    QString teamId = data.value(QStringLiteral("team_id")).toString();
+    QString userId = data.value(QStringLiteral("user_id")).toString();
+    QString teamName = data.value(QStringLiteral("team")).toString();
     qDebug() << "Login success" << userId << teamId << teamName;
 
     config->setUserId(userId);
@@ -468,7 +476,7 @@ void SlackClient::handleTestLoginReply()
 void SlackClient::start()
 {
     qDebug() << "Start init";
-    QNetworkReply *reply = executeGet("rtm.start");
+    QNetworkReply *reply = executeGet(QStringLiteral("rtm.start"));
     connect(reply, &QNetworkReply::finished, this, &SlackClient::handleStartReply);
 }
 
@@ -498,7 +506,7 @@ void SlackClient::handleStartReply()
     parseGroups(data);
     parseChats(data);
 
-    QUrl url(data.value("url").toString());
+    QUrl url(data.value(QStringLiteral("url")).toString());
     stream->listen(url);
 
     Storage::clearChannelMessages();
@@ -507,120 +515,120 @@ void SlackClient::handleStartReply()
     reply->deleteLater();
 }
 
-QVariantMap SlackClient::parseChannel(QJsonObject channel)
+QVariantMap SlackClient::parseChannel(const QJsonObject& channel)
 {
     QVariantMap data;
-    data.insert("id", channel.value("id").toVariant());
-    data.insert("type", QVariant("channel"));
-    data.insert("category", QVariant("channel"));
-    data.insert("name", channel.value("name").toVariant());
-    data.insert("presence", QVariant("none"));
-    data.insert("isOpen", channel.value("is_member").toVariant());
-    data.insert("lastRead", channel.value("last_read").toVariant());
-    data.insert("unreadCount", channel.value("unread_count_display").toVariant());
-    data.insert("userId", QVariant());
+    data.insert(QStringLiteral("id"), channel.value(QStringLiteral("id")).toVariant());
+    data.insert(QStringLiteral("type"), QVariant(QStringLiteral("channel")));
+    data.insert(QStringLiteral("category"), QVariant(QStringLiteral("channel")));
+    data.insert(QStringLiteral("name"), channel.value(QStringLiteral("name")).toVariant());
+    data.insert(QStringLiteral("presence"), QVariant(QStringLiteral("none")));
+    data.insert(QStringLiteral("isOpen"), channel.value(QStringLiteral("is_member")).toVariant());
+    data.insert(QStringLiteral("lastRead"), channel.value(QStringLiteral("last_read")).toVariant());
+    data.insert(QStringLiteral("unreadCount"), channel.value(QStringLiteral("unread_count_display")).toVariant());
+    data.insert(QStringLiteral("userId"), QVariant());
     return data;
 }
 
-QVariantMap SlackClient::parseGroup(QJsonObject group)
+QVariantMap SlackClient::parseGroup(const QJsonObject& group)
 {
     QVariantMap data;
 
-    if (group.value("is_mpim").toBool()) {
-        data.insert("type", QVariant("mpim"));
-        data.insert("category", QVariant("chat"));
+    if (group.value(QStringLiteral("is_mpim")).toBool()) {
+        data.insert(QStringLiteral("type"), QVariant(QStringLiteral("mpim")));
+        data.insert(QStringLiteral("category"), QVariant(QStringLiteral("chat")));
 
         QStringList members;
-        QJsonArray memberList = group.value("members").toArray();
+        QJsonArray memberList = group.value(QStringLiteral("members")).toArray();
         foreach (const QJsonValue &member, memberList) {
             QVariant memberId = member.toVariant();
 
             if (memberId != config->userId()) {
-                members << Storage::user(memberId).value("name").toString();
+                members << Storage::user(memberId).value(QStringLiteral("name")).toString();
             }
         }
-        data.insert("name", QVariant(members.join(", ")));
+        data.insert(QStringLiteral("name"), QVariant(members.join(QStringLiteral(", "))));
     } else {
-        data.insert("type", QVariant("group"));
-        data.insert("category", QVariant("channel"));
-        data.insert("name", group.value("name").toVariant());
+        data.insert(QStringLiteral("type"), QVariant(QStringLiteral("group")));
+        data.insert(QStringLiteral("category"), QVariant(QStringLiteral("channel")));
+        data.insert(QStringLiteral("name"), group.value(QStringLiteral("name")).toVariant());
     }
 
-    data.insert("id", group.value("id").toVariant());
-    data.insert("presence", QVariant("none"));
-    data.insert("isOpen", group.value("is_open").toVariant());
-    data.insert("lastRead", group.value("last_read").toVariant());
-    data.insert("unreadCount", group.value("unread_count_display").toVariant());
-    data.insert("userId", QVariant());
+    data.insert(QStringLiteral("id"), group.value(QStringLiteral("id")).toVariant());
+    data.insert(QStringLiteral("presence"), QVariant(QStringLiteral("none")));
+    data.insert(QStringLiteral("isOpen"), group.value(QStringLiteral("is_open")).toVariant());
+    data.insert(QStringLiteral("lastRead"), group.value(QStringLiteral("last_read")).toVariant());
+    data.insert(QStringLiteral("unreadCount"), group.value(QStringLiteral("unread_count_display")).toVariant());
+    data.insert(QStringLiteral("userId"), QVariant());
     return data;
 }
 
-void SlackClient::parseUsers(QJsonObject data)
+void SlackClient::parseUsers(const QJsonObject& data)
 {
-    foreach (const QJsonValue &value, data.value("users").toArray()) {
+    foreach (const QJsonValue &value, data.value(QStringLiteral("users")).toArray()) {
         QJsonObject user = value.toObject();
 
         QVariantMap data;
-        const QString userId = user.value("id").toString();
-        data.insert("id", userId);
-        data.insert("name", user.value("name").toVariant());
-        data.insert("presence", user.value("presence").toVariant());
+        const QString userId = user.value(QStringLiteral("id")).toString();
+        data.insert(QStringLiteral("id"), userId);
+        data.insert(QStringLiteral("name"), user.value(QStringLiteral("name")).toVariant());
+        data.insert(QStringLiteral("presence"), user.value(QStringLiteral("presence")).toVariant());
 
-        QJsonObject profile = user.value("profile").toObject();
-        m_userAvatars[userId] = QUrl(profile["image_512"].toString());
+        QJsonObject profile = user.value(QStringLiteral("profile")).toObject();
+        m_userAvatars[userId] = QUrl(profile[QStringLiteral("image_512")].toString());
 
         Storage::saveUser(data);
     }
 }
 
-void SlackClient::parseBots(QJsonObject data)
+void SlackClient::parseBots(const QJsonObject& data)
 {
-    foreach (const QJsonValue &value, data.value("bots").toArray()) {
+    foreach (const QJsonValue &value, data.value(QStringLiteral("bots")).toArray()) {
         QJsonObject bot = value.toObject();
 
         QVariantMap data;
-        data.insert("id", bot.value("id"));
-        data.insert("name", bot.value("name"));
-        data.insert("presence", QVariant("active"));
+        data.insert(QStringLiteral("id"), bot.value(QStringLiteral("id")));
+        data.insert(QStringLiteral("name"), bot.value(QStringLiteral("name")));
+        data.insert(QStringLiteral("presence"), QVariant(QStringLiteral("active")));
         Storage::saveUser(data);
     }
 }
 
-void SlackClient::parseChannels(QJsonObject data)
+void SlackClient::parseChannels(const QJsonObject& data)
 {
-    foreach (const QJsonValue &value, data.value("channels").toArray()) {
+    foreach (const QJsonValue &value, data.value(QStringLiteral("channels")).toArray()) {
         QVariantMap data = parseChannel(value.toObject());
         Storage::saveChannel(data);
     }
 }
 
-void SlackClient::parseGroups(QJsonObject data)
+void SlackClient::parseGroups(const QJsonObject& data)
 {
-    foreach (const QJsonValue &value, data.value("groups").toArray()) {
+    foreach (const QJsonValue &value, data.value(QStringLiteral("groups")).toArray()) {
         QVariantMap data = parseGroup(value.toObject());
         Storage::saveChannel(data);
     }
 }
 
-void SlackClient::parseChats(QJsonObject data)
+void SlackClient::parseChats(const QJsonObject& data)
 {
     qDebug() << "parse chats"; // << data;
-    foreach (const QJsonValue &value, data.value("ims").toArray()) {
+    foreach (const QJsonValue &value, data.value(QStringLiteral("ims")).toArray()) {
         QJsonObject chat = value.toObject();
         QVariantMap data;
 
-        QVariant userId = chat.value("user").toVariant();
+        QVariant userId = chat.value(QStringLiteral("user")).toVariant();
         QVariantMap user = Storage::user(userId);
 
-        data.insert("type", QVariant("im"));
-        data.insert("category", QVariant("chat"));
-        data.insert("id", chat.value("id").toVariant());
-        data.insert("userId", userId);
-        data.insert("name", user.value("name"));
-        data.insert("presence", user.value("presence"));
-        data.insert("isOpen", chat.value("is_open").toVariant());
-        data.insert("lastRead", chat.value("last_read").toVariant());
-        data.insert("unreadCount", chat.value("unread_count_display").toVariant());
+        data.insert(QStringLiteral("type"), QVariant(QStringLiteral("im")));
+        data.insert(QStringLiteral("category"), QVariant(QStringLiteral("chat")));
+        data.insert(QStringLiteral("id"), chat.value(QStringLiteral("id")).toVariant());
+        data.insert(QStringLiteral("userId"), userId);
+        data.insert(QStringLiteral("name"), user.value(QStringLiteral("name")));
+        data.insert(QStringLiteral("presence"), user.value(QStringLiteral("presence")));
+        data.insert(QStringLiteral("isOpen"), chat.value(QStringLiteral("is_open")).toVariant());
+        data.insert(QStringLiteral("lastRead"), chat.value(QStringLiteral("last_read")).toVariant());
+        data.insert(QStringLiteral("unreadCount"), chat.value(QStringLiteral("unread_count_display")).toVariant());
         Storage::saveChannel(data);
     }
 }
@@ -630,7 +638,7 @@ QVariantList SlackClient::getChannels()
     return Storage::channels();
 }
 
-QVariant SlackClient::getChannel(QString channelId)
+QVariant SlackClient::getChannel(const QString& channelId)
 {
     return Storage::channel(QVariant(channelId));
 }
@@ -653,7 +661,7 @@ QString SlackClient::lastChannel()
 {
     if (m_lastChannel.isEmpty()) {
         QSettings settings;
-        m_lastChannel = settings.value("LastChannel").toString();
+        m_lastChannel = settings.value(QStringLiteral("LastChannel")).toString();
         if (m_lastChannel.isEmpty() && !Storage::channels().isEmpty()) {
             m_lastChannel = Storage::channels().first().toMap()["id"].toString();
         }
@@ -662,27 +670,27 @@ QString SlackClient::lastChannel()
     return m_lastChannel;
 }
 
-QString SlackClient::historyMethod(QString type)
+QString SlackClient::historyMethod(const QString& type)
 {
-    if (type == "channel") {
-        return "channels.history";
-    } else if (type == "group") {
-        return "groups.history";
-    } else if (type == "mpim") {
-        return "mpim.history";
-    } else if (type == "im") {
-        return "im.history";
+    if (type == QStringLiteral("channel")) {
+        return QStringLiteral("channels.history");
+    } else if (type == QStringLiteral("group")) {
+        return QStringLiteral("groups.history");
+    } else if (type == QStringLiteral("mpim")) {
+        return QStringLiteral("mpim.history");
+    } else if (type == QStringLiteral("im")) {
+        return QStringLiteral("im.history");
     } else {
         return "";
     }
 }
 
-void SlackClient::joinChannel(QString channelId)
+void SlackClient::joinChannel(const QString& channelId)
 {
     QVariantMap channel = Storage::channel(QVariant(channelId));
 
     QMap<QString, QString> params;
-    params.insert("name", channel.value("name").toString());
+    params.insert(QStringLiteral("name"), channel.value(QStringLiteral("name")).toString());
 
     QNetworkReply *reply = executeGet("channels.join", params);
     connect(reply, &QNetworkReply::finished, this, &SlackClient::handleJoinChannelReply);
@@ -701,12 +709,12 @@ void SlackClient::handleJoinChannelReply()
     reply->deleteLater();
 }
 
-void SlackClient::leaveChannel(QString channelId)
+void SlackClient::leaveChannel(const QString& channelId)
 {
     QMap<QString, QString> params;
-    params.insert("channel", channelId);
+    params.insert(QStringLiteral("channel"), channelId);
 
-    QNetworkReply *reply = executeGet("channels.leave", params);
+    QNetworkReply *reply = executeGet(QStringLiteral("channels.leave"), params);
     connect(reply, &QNetworkReply::finished, this, &SlackClient::handleLeaveChannelReply);
 }
 
@@ -722,12 +730,12 @@ void SlackClient::handleLeaveChannelReply()
     reply->deleteLater();
 }
 
-void SlackClient::leaveGroup(QString groupId)
+void SlackClient::leaveGroup(const QString& groupId)
 {
     QMap<QString, QString> params;
-    params.insert("channel", groupId);
+    params.insert(QStringLiteral("channel"), groupId);
 
-    QNetworkReply *reply = executeGet("groups.leave", params);
+    QNetworkReply *reply = executeGet(QStringLiteral("groups.leave"), params);
     connect(reply, &QNetworkReply::finished, this, &SlackClient::handleLeaveGroupReply);
 }
 
@@ -743,14 +751,14 @@ void SlackClient::handleLeaveGroupReply()
     reply->deleteLater();
 }
 
-void SlackClient::openChat(QString chatId)
+void SlackClient::openChat(const QString& chatId)
 {
     QVariantMap channel = Storage::channel(QVariant(chatId));
 
     QMap<QString, QString> params;
-    params.insert("user", channel.value("userId").toString());
+    params.insert(QStringLiteral("user"), channel.value(QStringLiteral("userId")).toString());
 
-    QNetworkReply *reply = executeGet("im.open", params);
+    QNetworkReply *reply = executeGet(QStringLiteral("im.open"), params);
     connect(reply, &QNetworkReply::finished, this, &SlackClient::handleOpenChatReply);
 }
 
@@ -767,12 +775,12 @@ void SlackClient::handleOpenChatReply()
     reply->deleteLater();
 }
 
-void SlackClient::closeChat(QString chatId)
+void SlackClient::closeChat(const QString& chatId)
 {
     QMap<QString, QString> params;
-    params.insert("channel", chatId);
+    params.insert(QStringLiteral("channel"), chatId);
 
-    QNetworkReply *reply = executeGet("im.close", params);
+    QNetworkReply *reply = executeGet(QStringLiteral("im.close"), params);
     connect(reply, &QNetworkReply::finished, this, &SlackClient::handleCloseChatReply);
 }
 
@@ -788,7 +796,7 @@ void SlackClient::handleCloseChatReply()
     reply->deleteLater();
 }
 
-void SlackClient::loadMessages(QString type, QString channelId)
+void SlackClient::loadMessages(const QString& type, const QString& channelId)
 {
     if (Storage::channelMessagesExist(channelId)) {
         QVariantList messages = Storage::channelMessages(channelId);
@@ -797,7 +805,7 @@ void SlackClient::loadMessages(QString type, QString channelId)
     }
 
     QMap<QString, QString> params;
-    params.insert("channel", channelId);
+    params.insert(QStringLiteral("channel"), channelId);
 
     QNetworkReply *reply = executeGet(historyMethod(type), params);
     reply->setProperty("channelId", channelId);
@@ -809,14 +817,14 @@ void SlackClient::handleLoadMessagesReply()
     QNetworkReply *reply = qobject_cast<QNetworkReply *>(sender());
 
     QJsonObject data = getResult(reply);
+    reply->deleteLater();
 
     if (isError(data)) {
-        reply->deleteLater();
         emit loadMessagesFail();
         return;
     }
 
-    QJsonArray messageList = data.value("messages").toArray();
+    QJsonArray messageList = data.value(QStringLiteral("messages")).toArray();
     QVariantList messages;
 
     foreach (const QJsonValue &value, messageList) {
@@ -828,29 +836,28 @@ void SlackClient::handleLoadMessagesReply()
     Storage::setChannelMessages(channelId, messages);
 
     emit loadMessagesSuccess(channelId, messages);
-    reply->deleteLater();
 }
 
-QString SlackClient::markMethod(QString type)
+QString SlackClient::markMethod(const QString& type)
 {
-    if (type == "channel") {
-        return "channels.mark";
-    } else if (type == "group") {
-        return "groups.mark";
-    } else if (type == "mpim") {
-        return "mpim.mark";
-    } else if (type == "im") {
-        return "im.mark";
+    if (type == QStringLiteral("channel")) {
+        return QStringLiteral("channels.mark");
+    } else if (type == QStringLiteral("group")) {
+        return QStringLiteral("groups.mark");
+    } else if (type == QStringLiteral("mpim")) {
+        return QStringLiteral("mpim.mark");
+    } else if (type == QStringLiteral("im")) {
+        return QStringLiteral("im.mark");
     } else {
         return "";
     }
 }
 
-void SlackClient::markChannel(QString type, QString channelId, QString time)
+void SlackClient::markChannel(const QString& type, const QString& channelId, const QString& time)
 {
     QMap<QString, QString> params;
-    params.insert("channel", channelId);
-    params.insert("ts", time);
+    params.insert(QStringLiteral("channel"), channelId);
+    params.insert(QStringLiteral("ts"), time);
 
     QNetworkReply *reply = executeGet(markMethod(type), params);
     connect(reply, &QNetworkReply::finished, this, &SlackClient::handleMarkChannelReply);
@@ -866,19 +873,19 @@ void SlackClient::handleMarkChannelReply()
     reply->deleteLater();
 }
 
-void SlackClient::postMessage(QString channelId, QString content)
+void SlackClient::postMessage(const QString& channelId, QString& content)
 {
-    content.replace(QRegularExpression("&"), "&amp;");
-    content.replace(QRegularExpression(">"), "&gt;");
-    content.replace(QRegularExpression("<"), "&lt;");
+    content.replace(QRegularExpression("&"), QStringLiteral("&amp;"));
+    content.replace(QRegularExpression(">"), QStringLiteral("&gt;"));
+    content.replace(QRegularExpression("<"), QStringLiteral("&lt;"));
 
     QMap<QString, QString> data;
-    data.insert("channel", channelId);
-    data.insert("text", content);
-    data.insert("as_user", "true");
-    data.insert("parse", "full");
+    data.insert(QStringLiteral("channel"), channelId);
+    data.insert(QStringLiteral("text"), content);
+    data.insert(QStringLiteral("as_user"), QStringLiteral("true"));
+    data.insert(QStringLiteral("parse"), QStringLiteral("full"));
 
-    QNetworkReply *reply = executePost("chat.postMessage", data);
+    QNetworkReply *reply = executePost(QStringLiteral("chat.postMessage"), data);
     connect(reply, &QNetworkReply::finished, this, &SlackClient::handlePostMessageReply);
 }
 
@@ -892,17 +899,18 @@ void SlackClient::handlePostMessageReply()
     reply->deleteLater();
 }
 
-void SlackClient::postImage(QString channelId, QString imagePath, QString title, QString comment)
+void SlackClient::postImage(const QString& channelId, const QString& imagePath,
+                            const QString& title, const QString& comment)
 {
     QMap<QString, QString> data;
-    data.insert("channels", channelId);
+    data.insert(QStringLiteral("channels"), channelId);
 
     if (!title.isEmpty()) {
-        data.insert("title", title);
+        data.insert(QStringLiteral("title"), title);
     }
 
     if (!comment.isEmpty()) {
-        data.insert("initial_comment", comment);
+        data.insert(QStringLiteral("initial_comment"), comment);
     }
 
     QFile *imageFile = new QFile(imagePath);
@@ -912,7 +920,7 @@ void SlackClient::postImage(QString channelId, QString imagePath, QString title,
     }
 
     qDebug() << "sending image" << imagePath;
-    QNetworkReply *reply = executePostWithFile("files.upload", data, imageFile);
+    QNetworkReply *reply = executePostWithFile(QStringLiteral("files.upload"), data, imageFile);
 
     connect(reply, &QNetworkReply::finished, this, &SlackClient::handlePostImage);
     connect(reply, &QNetworkReply::finished, imageFile, &QObject::deleteLater);
@@ -934,16 +942,16 @@ void SlackClient::handlePostImage()
     reply->deleteLater();
 }
 
-QVariantMap SlackClient::getMessageData(const QJsonObject message)
+QVariantMap SlackClient::getMessageData(const QJsonObject& message)
 {
     QVariantMap data;
-    data.insert("type", message.value("type").toVariant());
-    data.insert("time", message.value("ts").toVariant());
-    data.insert("channel", message.value("channel").toVariant());
-    data.insert("user", user(message));
-    data.insert("attachments", getAttachments(message));
-    data.insert("images", getImages(message));
-    data.insert("content", QVariant(getContent(message)));
+    data.insert(QStringLiteral("type"), message.value(QStringLiteral("type")).toVariant());
+    data.insert(QStringLiteral("time"), message.value(QStringLiteral("ts")).toVariant());
+    data.insert(QStringLiteral("channel"), message.value(QStringLiteral("channel")).toVariant());
+    data.insert(QStringLiteral("user"), user(message));
+    data.insert(QStringLiteral("attachments"), getAttachments(message));
+    data.insert(QStringLiteral("images"), getImages(message));
+    data.insert(QStringLiteral("content"), QVariant(getContent(message)));
 
     return data;
 }
@@ -951,36 +959,36 @@ QVariantMap SlackClient::getMessageData(const QJsonObject message)
 QVariantMap SlackClient::user(const QJsonObject &data)
 {
 
-    QString type = data.value("subtype").toString("default");
+    QString type = data.value(QStringLiteral("subtype")).toString(QStringLiteral("default"));
     QVariant userId;
 
-    if (type == "bot_message") {
-        userId = data.value("bot_id").toVariant();
+    if (type == QStringLiteral("bot_message")) {
+        userId = data.value(QStringLiteral("bot_id")).toVariant();
     } else {
-        userId = data.value("user").toVariant();
+        userId = data.value(QStringLiteral("user")).toVariant();
     }
 
     QVariantMap userData = Storage::user(userId);
 
     if (userData.isEmpty()) {
-        userData.insert("id", data.value("user").toVariant());
-        userData.insert("name", QVariant("Unknown"));
-        userData.insert("presence", QVariant("away"));
+        userData.insert(QStringLiteral("id"), data.value(QStringLiteral("user")).toVariant());
+        userData.insert(QStringLiteral("name"), QVariant(QStringLiteral("Unknown")));
+        userData.insert(QStringLiteral("presence"), QVariant(QStringLiteral("away")));
     }
 
-    QString username = data.value("username").toString();
+    QString username = data.value(QStringLiteral("username")).toString();
     if (!username.isEmpty()) {
-        QRegularExpression newUserPattern("<@([A-Z0-9]+)\\|([^>]+)>");
-        username.replace(newUserPattern, "\\2");
-        userData.insert("name", username);
+        QRegularExpression newUserPattern(QStringLiteral("<@([A-Z0-9]+)\\|([^>]+)>"));
+        username.replace(newUserPattern, QStringLiteral("\\2"));
+        userData.insert(QStringLiteral("name"), username);
     }
 
     return userData;
 }
 
-QString SlackClient::getContent(QJsonObject message)
+QString SlackClient::getContent(const QJsonObject& message)
 {
-    QString content = message.value("text").toString();
+    QString content = message.value(QStringLiteral("text")).toString();
 
     findNewUsers(content);
     MessageFormatter::replaceUserInfo(content);
@@ -994,36 +1002,38 @@ QString SlackClient::getContent(QJsonObject message)
     return content;
 }
 
-QVariantList SlackClient::getImages(QJsonObject message)
+QVariantList SlackClient::getImages(const QJsonObject& message)
 {
     QVariantList images;
 
-    if (message.value("subtype").toString() == "file_share") {
+    if (message.value(QStringLiteral("subtype")).toString() == QStringLiteral("file_share")) {
         QStringList imageTypes;
-        imageTypes << "jpg";
-        imageTypes << "png";
-        imageTypes << "gif";
+        imageTypes << QStringLiteral("jpg");
+        imageTypes << QStringLiteral("png");
+        imageTypes << QStringLiteral("gif");
 
-        QJsonObject file = message.value("file").toObject();
-        QString fileType = file.value("filetype").toString();
+        QJsonObject file = message.value(QStringLiteral("file")).toObject();
+        QString fileType = file.value(QStringLiteral("filetype")).toString();
 
         if (imageTypes.contains(fileType)) {
-            QString thumbItem = file.contains("thumb_480") ? "480" : "360";
+            QString thumbItem = file.contains(QStringLiteral("thumb_480")) ?
+                        QStringLiteral("480") :
+                        QStringLiteral("360");
 
             QVariantMap thumbSize;
-            thumbSize.insert("width", file.value("thumb_" + thumbItem + "_w").toVariant());
-            thumbSize.insert("height", file.value("thumb_" + thumbItem + "_h").toVariant());
+            thumbSize.insert(QStringLiteral("width"), file.value("thumb_" + thumbItem + "_w").toVariant());
+            thumbSize.insert(QStringLiteral("height"), file.value("thumb_" + thumbItem + "_h").toVariant());
 
             QVariantMap imageSize;
-            imageSize.insert("width", file.value("original_w").toVariant());
-            imageSize.insert("height", file.value("original_h").toVariant());
+            imageSize.insert(QStringLiteral("width"), file.value("original_w").toVariant());
+            imageSize.insert(QStringLiteral("height"), file.value("original_h").toVariant());
 
             QVariantMap fileData;
-            fileData.insert("name", file.value("name").toVariant());
-            fileData.insert("url", file.value("url_private").toVariant());
-            fileData.insert("size", imageSize);
-            fileData.insert("thumbSize", thumbSize);
-            fileData.insert("thumbUrl", file.value("thumb_" + thumbItem).toVariant());
+            fileData.insert(QStringLiteral("name"), file.value(QStringLiteral("name")).toVariant());
+            fileData.insert(QStringLiteral("url"), file.value(QStringLiteral("url_private")).toVariant());
+            fileData.insert(QStringLiteral("size"), imageSize);
+            fileData.insert(QStringLiteral("thumbSize"), thumbSize);
+            fileData.insert(QStringLiteral("thumbUrl"), file.value("thumb_" + thumbItem).toVariant());
 
             images.append(fileData);
             qDebug() << fileData;
@@ -1033,20 +1043,20 @@ QVariantList SlackClient::getImages(QJsonObject message)
     return images;
 }
 
-QVariantList SlackClient::getAttachments(QJsonObject message)
+QVariantList SlackClient::getAttachments(const QJsonObject& message)
 {
-    QJsonArray attachementList = message.value("attachments").toArray();
+    QJsonArray attachementList = message.value(QStringLiteral("attachments")).toArray();
     QVariantList attachments;
 
     foreach (const QJsonValue &value, attachementList) {
         QJsonObject attachment = value.toObject();
         QVariantMap data;
 
-        QString titleLink = attachment.value("title_link").toString();
-        QString title = attachment.value("title").toString();
-        QString pretext = attachment.value("pretext").toString();
-        QString text = attachment.value("text").toString();
-        QString fallback = attachment.value("fallback").toString();
+        QString titleLink = attachment.value(QStringLiteral("title_link")).toString();
+        QString title = attachment.value(QStringLiteral("title")).toString();
+        QString pretext = attachment.value(QStringLiteral("pretext")).toString();
+        QString text = attachment.value(QStringLiteral("text")).toString();
+        QString fallback = attachment.value(QStringLiteral("fallback")).toString();
         QString color = getAttachmentColor(attachment);
         QVariantList fields = getAttachmentFields(attachment);
         QVariantList images = getAttachmentImages(attachment);
@@ -1065,13 +1075,13 @@ QVariantList SlackClient::getAttachments(QJsonObject message)
             title = "<a href=\"" + titleLink + "\">" + title + "</a>";
         }
 
-        data.insert("title", QVariant(title));
-        data.insert("pretext", QVariant(pretext));
-        data.insert("content", QVariant(text));
-        data.insert("fallback", QVariant(fallback));
-        data.insert("indicatorColor", QVariant(color));
-        data.insert("fields", QVariant(fields));
-        data.insert("images", QVariant(images));
+        data.insert(QStringLiteral("title"), QVariant(title));
+        data.insert(QStringLiteral("pretext"), QVariant(pretext));
+        data.insert(QStringLiteral("content"), QVariant(text));
+        data.insert(QStringLiteral("fallback"), QVariant(fallback));
+        data.insert(QStringLiteral("indicatorColor"), QVariant(color));
+        data.insert(QStringLiteral("fields"), QVariant(fields));
+        data.insert(QStringLiteral("images"), QVariant(images));
 
         attachments.append(data);
     }
@@ -1079,45 +1089,45 @@ QVariantList SlackClient::getAttachments(QJsonObject message)
     return attachments;
 }
 
-QString SlackClient::getAttachmentColor(QJsonObject attachment)
+QString SlackClient::getAttachmentColor(const QJsonObject& attachment)
 {
-    QString color = attachment.value("color").toString();
+    QString color = attachment.value(QStringLiteral("color")).toString();
 
     if (color.isEmpty()) {
-        color = "theme";
-    } else if (color == "good") {
-        color = "#6CC644";
-    } else if (color == "warning") {
-        color = "#E67E22";
-    } else if (color == "danger") {
-        color = "#D00000";
-    } else if (!color.startsWith('#')) {
+        color = QStringLiteral("theme");
+    } else if (color == QStringLiteral("good")) {
+        color = QStringLiteral("#6CC644");
+    } else if (color == QStringLiteral("warning")) {
+        color = QStringLiteral("#E67E22");
+    } else if (color == QStringLiteral("danger")) {
+        color = QStringLiteral("#D00000");
+    } else if (!color.startsWith("#")) {
         color = "#" + color;
     }
 
     return color;
 }
 
-QVariantList SlackClient::getAttachmentFields(QJsonObject attachment)
+QVariantList SlackClient::getAttachmentFields(const QJsonObject& attachment)
 {
     QVariantList fields;
-    if (attachment.contains("fields")) {
-        QJsonArray fieldList = attachment.value("fields").toArray();
+    if (attachment.contains(QStringLiteral("fields"))) {
+        QJsonArray fieldList = attachment.value(QStringLiteral("fields")).toArray();
 
         foreach (const QJsonValue &fieldValue, fieldList) {
             QJsonObject field = fieldValue.toObject();
-            QString title = field.value("title").toString();
-            QString value = field.value("value").toString();
-            bool isShort = field.value("short").toBool();
+            QString title = field.value(QStringLiteral("title")).toString();
+            QString value = field.value(QStringLiteral("value")).toString();
+            bool isShort = field.value(QStringLiteral("short")).toBool();
 
             if (!title.isEmpty()) {
                 MessageFormatter::replaceLinks(title);
                 MessageFormatter::replaceMarkdown(title);
 
                 QVariantMap titleData;
-                titleData.insert("isTitle", QVariant(true));
-                titleData.insert("isShort", QVariant(isShort));
-                titleData.insert("content", QVariant(title));
+                titleData.insert(QStringLiteral("isTitle"), QVariant(true));
+                titleData.insert(QStringLiteral("isShort"), QVariant(isShort));
+                titleData.insert(QStringLiteral("content"), QVariant(title));
                 fields.append(titleData);
             }
 
@@ -1126,9 +1136,9 @@ QVariantList SlackClient::getAttachmentFields(QJsonObject attachment)
                 MessageFormatter::replaceMarkdown(value);
 
                 QVariantMap valueData;
-                valueData.insert("isTitle", QVariant(false));
-                valueData.insert("isShort", QVariant(isShort));
-                valueData.insert("content", QVariant(value));
+                valueData.insert(QStringLiteral("isTitle"), QVariant(false));
+                valueData.insert(QStringLiteral("isShort"), QVariant(isShort));
+                valueData.insert(QStringLiteral("content"), QVariant(value));
                 fields.append(valueData);
             }
         }
@@ -1137,18 +1147,18 @@ QVariantList SlackClient::getAttachmentFields(QJsonObject attachment)
     return fields;
 }
 
-QVariantList SlackClient::getAttachmentImages(QJsonObject attachment)
+QVariantList SlackClient::getAttachmentImages(const QJsonObject& attachment)
 {
     QVariantList images;
 
-    if (attachment.contains("image_url")) {
+    if (attachment.contains(QStringLiteral("image_url"))) {
         QVariantMap size;
-        size.insert("width", attachment.value("image_width"));
-        size.insert("height", attachment.value("image_height"));
+        size.insert(QStringLiteral("width"), attachment.value(QStringLiteral("image_width")));
+        size.insert(QStringLiteral("height"), attachment.value(QStringLiteral("image_height")));
 
         QVariantMap image;
-        image.insert("url", attachment.value("image_url"));
-        image.insert("size", size);
+        image.insert(QStringLiteral("url"), attachment.value(QStringLiteral("image_url")));
+        image.insert(QStringLiteral("size"), size);
 
         images.append(image);
     }
@@ -1158,7 +1168,7 @@ QVariantList SlackClient::getAttachmentImages(QJsonObject attachment)
 
 void SlackClient::findNewUsers(const QString &message)
 {
-    QRegularExpression newUserPattern("<@([A-Z0-9]+)\\|([^>]+)>");
+    QRegularExpression newUserPattern(QStringLiteral("<@([A-Z0-9]+)\\|([^>]+)>"));
 
     QRegularExpressionMatchIterator i = newUserPattern.globalMatch(message);
     while (i.hasNext()) {
@@ -1168,15 +1178,15 @@ void SlackClient::findNewUsers(const QString &message)
         if (Storage::user(id).isEmpty()) {
             QString name = match.captured(2);
             QVariantMap data;
-            data.insert("id", QVariant(id));
-            data.insert("name", QVariant(name));
-            data.insert("presence", QVariant("active"));
+            data.insert(QStringLiteral("id"), QVariant(id));
+            data.insert(QStringLiteral("name"), QVariant(name));
+            data.insert(QStringLiteral("presence"), QVariant(QStringLiteral("active")));
             Storage::saveUser(data);
         }
     }
 }
 
-void SlackClient::sendNotification(QString channelId, QString title, QString text)
+void SlackClient::sendNotification(const QString& channelId, const QString& title, const QString& text)
 {
     QString body = text.length() > 100 ? text.left(97) + "..." : text;
     QString preview = text.length() > 40 ? text.left(37) + "..." : text;

--- a/src/slackclient.h
+++ b/src/slackclient.h
@@ -30,7 +30,7 @@ public:
     Q_INVOKABLE void setActiveWindow(const QString &windowId);
 
     Q_INVOKABLE QVariantList getChannels();
-    Q_INVOKABLE QVariant getChannel(QString channelId);
+    Q_INVOKABLE QVariant getChannel(const QString& channelId);
 
     bool isOnline() const;
     bool isDevice() const;
@@ -77,44 +77,44 @@ public slots:
     void start();
     void handleStartReply();
 
-    void fetchAccessToken(QUrl url);
+    void fetchAccessToken(const QUrl& url);
     void handleAccessTokenReply();
 
     void testLogin();
     void handleTestLoginReply();
 
-    void loadMessages(QString type, QString channelId);
+    void loadMessages(const QString& type, const QString& channelId);
     void handleLoadMessagesReply();
 
-    void postMessage(QString channelId, QString content);
+    void postMessage(const QString& channelId, QString &content);
     void handlePostMessageReply();
 
-    void postImage(QString channelId, QString imagePath, QString title, QString comment);
+    void postImage(const QString& channelId, const QString& imagePath, const QString& title, const QString& comment);
     void handlePostImage();
 
-    void markChannel(QString type, QString channelId, QString time);
+    void markChannel(const QString& type, const QString& channelId, const QString& time);
     void handleMarkChannelReply();
 
-    void joinChannel(QString channelId);
+    void joinChannel(const QString& channelId);
     void handleJoinChannelReply();
 
-    void leaveChannel(QString channelId);
+    void leaveChannel(const QString& channelId);
     void handleLeaveChannelReply();
 
-    void leaveGroup(QString groupId);
+    void leaveGroup(const QString& groupId);
     void handleLeaveGroupReply();
 
-    void openChat(QString chatId);
+    void openChat(const QString& chatId);
     void handleOpenChatReply();
 
-    void closeChat(QString chatId);
+    void closeChat(const QString& chatId);
     void handleCloseChatReply();
 
     void handleNetworkAccessibleChanged(QNetworkAccessManager::NetworkAccessibility accessible);
 
     void handleStreamStart();
     void handleStreamEnd();
-    void handleStreamMessage(QJsonObject message);
+    void handleStreamMessage(const QJsonObject& message);
 
     void reconnect();
 
@@ -124,52 +124,52 @@ private:
     bool appActive;
     QString activeWindow;
 
-    QNetworkReply *executePost(QString method, const QMap<QString, QString> &data);
-    QNetworkReply *executePostWithFile(QString method, const QMap<QString, QString> &, QFile *file);
+    QNetworkReply *executePost(const QString& method, const QMap<QString, QString> &data);
+    QNetworkReply *executePostWithFile(const QString& method, const QMap<QString, QString> &, QFile *file);
 
-    QNetworkReply *executeGet(QString method, QMap<QString, QString> params = QMap<QString, QString>());
+    QNetworkReply *executeGet(const QString& method, const QMap<QString, QString>& params = QMap<QString, QString>());
 
     bool isOk(const QNetworkReply *reply);
     bool isError(const QJsonObject &data);
     QJsonObject getResult(QNetworkReply *reply);
 
-    void parseMessageUpdate(QJsonObject message);
-    void parseChannelUpdate(QJsonObject message);
-    void parseChannelJoin(QJsonObject message);
-    void parseChannelLeft(QJsonObject message);
-    void parseGroupJoin(QJsonObject message);
-    void parseChatOpen(QJsonObject message);
-    void parseChatClose(QJsonObject message);
-    void parsePresenceChange(QJsonObject message);
-    void parseNotification(QJsonObject message);
+    void parseMessageUpdate(const QJsonObject& message);
+    void parseChannelUpdate(const QJsonObject& message);
+    void parseChannelJoin(const QJsonObject& message);
+    void parseChannelLeft(const QJsonObject& message);
+    void parseGroupJoin(const QJsonObject& message);
+    void parseChatOpen(const QJsonObject& message);
+    void parseChatClose(const QJsonObject& message);
+    void parsePresenceChange(const QJsonObject& message);
+    void parseNotification(const QJsonObject& message);
 
-    QVariantMap getMessageData(const QJsonObject message);
+    QVariantMap getMessageData(const QJsonObject& message);
 
-    QString getContent(QJsonObject message);
-    QVariantList getAttachments(QJsonObject message);
-    QVariantList getImages(QJsonObject message);
-    QString getAttachmentColor(QJsonObject attachment);
-    QVariantList getAttachmentFields(QJsonObject attachment);
-    QVariantList getAttachmentImages(QJsonObject attachment);
+    QString getContent(const QJsonObject& message);
+    QVariantList getAttachments(const QJsonObject& message);
+    QVariantList getImages(const QJsonObject& message);
+    QString getAttachmentColor(const QJsonObject& attachment);
+    QVariantList getAttachmentFields(const QJsonObject& attachment);
+    QVariantList getAttachmentImages(const QJsonObject& attachment);
 
-    QVariantMap parseChannel(QJsonObject data);
-    QVariantMap parseGroup(QJsonObject group);
+    QVariantMap parseChannel(const QJsonObject& data);
+    QVariantMap parseGroup(const QJsonObject& group);
 
-    void parseUsers(QJsonObject data);
-    void parseBots(QJsonObject data);
-    void parseChannels(QJsonObject data);
-    void parseGroups(QJsonObject data);
-    void parseChats(QJsonObject data);
+    void parseUsers(const QJsonObject& data);
+    void parseBots(const QJsonObject& data);
+    void parseChannels(const QJsonObject& data);
+    void parseGroups(const QJsonObject& data);
+    void parseChats(const QJsonObject& data);
 
     void findNewUsers(const QString &message);
 
-    void sendNotification(QString channelId, QString title, QString content);
+    void sendNotification(const QString& channelId, const QString& title, const QString& content);
     void clearNotifications();
 
     QVariantMap user(const QJsonObject &data);
 
-    QString historyMethod(QString type);
-    QString markMethod(QString type);
+    QString historyMethod(const QString& type);
+    QString markMethod(const QString& type);
 
     QPointer<QNetworkAccessManager> networkAccessManager;
     QPointer<SlackConfig> config;

--- a/src/storage.cpp
+++ b/src/storage.cpp
@@ -3,12 +3,14 @@
 #include <QDebug>
 
 QVariantMap Storage::userMap = QVariantMap();
+QVariantList Storage::userList = QVariantList();
 QVariantMap Storage::channelMap = QVariantMap();
 QVariantMap Storage::channelMessageMap = QVariantMap();
 
 void Storage::saveUser(const QVariantMap& user)
 {
     userMap.insert(user.value("id").toString(), user);
+    userList = userMap.values();
 }
 
 QVariantMap Storage::user(const QVariant& id)
@@ -16,9 +18,9 @@ QVariantMap Storage::user(const QVariant& id)
     return userMap.value(id.toString()).toMap();
 }
 
-QVariantList Storage::users()
+const QVariantList& Storage::users()
 {
-    return userMap.values();
+    return userList;
 }
 
 void Storage::saveChannel(const QVariantMap& channel)

--- a/src/storage.cpp
+++ b/src/storage.cpp
@@ -6,12 +6,12 @@ QVariantMap Storage::userMap = QVariantMap();
 QVariantMap Storage::channelMap = QVariantMap();
 QVariantMap Storage::channelMessageMap = QVariantMap();
 
-void Storage::saveUser(QVariantMap user)
+void Storage::saveUser(const QVariantMap& user)
 {
     userMap.insert(user.value("id").toString(), user);
 }
 
-QVariantMap Storage::user(QVariant id)
+QVariantMap Storage::user(const QVariant& id)
 {
     return userMap.value(id.toString()).toMap();
 }
@@ -21,12 +21,12 @@ QVariantList Storage::users()
     return userMap.values();
 }
 
-void Storage::saveChannel(QVariantMap channel)
+void Storage::saveChannel(const QVariantMap& channel)
 {
     channelMap.insert(channel.value("id").toString(), channel);
 }
 
-QVariantMap Storage::channel(QVariant id)
+QVariantMap Storage::channel(const QVariant& id)
 {
     return channelMap.value(id.toString()).toMap();
 }
@@ -36,22 +36,22 @@ QVariantList Storage::channels()
     return channelMap.values();
 }
 
-QVariantList Storage::channelMessages(QVariant channelId)
+QVariantList Storage::channelMessages(const QVariant& channelId)
 {
     return channelMessageMap.value(channelId.toString()).toList();
 }
 
-bool Storage::channelMessagesExist(QVariant channelId)
+bool Storage::channelMessagesExist(const QVariant& channelId)
 {
     return channelMessageMap.contains(channelId.toString());
 }
 
-void Storage::setChannelMessages(QVariant channelId, QVariantList messages)
+void Storage::setChannelMessages(const QVariant& channelId, const QVariantList& messages)
 {
     channelMessageMap.insert(channelId.toString(), messages);
 }
 
-void Storage::appendChannelMessage(QVariant channelId, QVariantMap message)
+void Storage::appendChannelMessage(const QVariant& channelId, const QVariantMap& message)
 {
     QVariantList messages = channelMessages(channelId);
     messages.append(message);

--- a/src/storage.h
+++ b/src/storage.h
@@ -7,18 +7,18 @@ class Storage : public QObject
 {
     Q_OBJECT
 public:
-    static QVariantMap user(QVariant id);
+    static QVariantMap user(const QVariant& id);
     static QVariantList users();
-    static void saveUser(QVariantMap user);
+    static void saveUser(const QVariantMap& user);
 
-    static QVariantMap channel(QVariant id);
+    static QVariantMap channel(const QVariant& id);
     static QVariantList channels();
-    static void saveChannel(QVariantMap channel);
+    static void saveChannel(const QVariantMap& channel);
 
-    static QVariantList channelMessages(QVariant channelId);
-    static bool channelMessagesExist(QVariant channelId);
-    static void setChannelMessages(QVariant channelId, QVariantList messages);
-    static void appendChannelMessage(QVariant channelId, QVariantMap message);
+    static QVariantList channelMessages(const QVariant& channelId);
+    static bool channelMessagesExist(const QVariant& channelId);
+    static void setChannelMessages(const QVariant& channelId, const QVariantList& messages);
+    static void appendChannelMessage(const QVariant& channelId, const QVariantMap& message);
     static void clearChannelMessages();
 
 signals:

--- a/src/storage.h
+++ b/src/storage.h
@@ -8,7 +8,7 @@ class Storage : public QObject
     Q_OBJECT
 public:
     static QVariantMap user(const QVariant& id);
-    static QVariantList users();
+    static const QVariantList &users();
     static void saveUser(const QVariantMap& user);
 
     static QVariantMap channel(const QVariant& id);
@@ -29,6 +29,7 @@ private:
     static QVariantMap userMap;
     static QVariantMap channelMap;
     static QVariantMap channelMessageMap;
+    static QVariantList userList;
 };
 
 #endif // STORAGE_H


### PR DESCRIPTION
Do not reallocate strings on each call
pass parameters by reference
Temporarily optimize Storage::users until get rid of QVariantMap/List